### PR TITLE
Add vertx-launcher repo

### DIFF
--- a/otterdog/eclipse-vertx.jsonnet
+++ b/otterdog/eclipse-vertx.jsonnet
@@ -347,6 +347,22 @@ orgs.newOrg('eclipse-vertx') {
         },
       ],
     },
+    orgs.newRepo('vertx-launcher') {
+      allow_update_branch: false,
+      description: "Vert.x Launcher",
+      homepage: "",
+      topics+: [
+        "vertx",
+        "launcher"
+      ],
+      web_commit_signoff_required: false,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          required_approving_review_count: null,
+          requires_approving_reviews: false,
+        },
+      ],
+    },
     orgs.newRepo('vertx-openapi') {
       allow_merge_commit: false,
       allow_update_branch: false,


### PR DESCRIPTION
This PR adds the vertx-launcher repo as requested in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3368.

It follows the convention of the already existing repos but adds some small changes that could also be changed for the other repos (will create a separate PR for that):

- enable secret scanning and secret scanning push protection
- use main as default branch
- enable status checks for the branch protection rule (which will enforce the eca check as inherited from the default config)