### PR TITLE
Add vertx-service-resolver repo

### DIFF
--- a/otterdog/eclipse-vertx.jsonnet
+++ b/otterdog/eclipse-vertx.jsonnet
@@ -539,5 +539,26 @@ orgs.newOrg('eclipse-vertx') {
         },
       ],
     },
+    orgs.newRepo('vertx-launcher') {
+       allow_update_branch: false,
+       description: "Vert.x Service Resolver",
+       homepage: "",
+       topics+: [
+         "java",
+         "vertx",
+         "jvm",
+         "microservices",
+         "kubernetes",
+         "loadbalancing",
+         "servicediscovery"
+       ],
+       web_commit_signoff_required: false,
+       branch_protection_rules: [
+         orgs.newBranchProtectionRule('main') {
+           required_approving_review_count: null,
+           requires_approving_reviews: false,
+         },
+       ],
+     },
   ],
 }


### PR DESCRIPTION
Add support for a `vertx-service-resolver` GitHub repository that will hold the code implementing the Address Resolver service provider interface of vertx-core project. 