### PR TITLE
Fix a few things in the vertx-service-resolver configuration

### DIFF
--- a/otterdog/eclipse-vertx.jsonnet
+++ b/otterdog/eclipse-vertx.jsonnet
@@ -443,25 +443,28 @@ orgs.newOrg('eclipse-vertx') {
       ],
     },
     orgs.newRepo('vertx-service-resolver') {
-       allow_update_branch: false,
-       description: "Vert.x Service Resolver",
-       homepage: "",
-       topics+: [
-         "java",
-         "vertx",
-         "jvm",
-         "microservices",
-         "kubernetes",
-         "loadbalancing",
-         "servicediscovery"
-       ],
-       web_commit_signoff_required: false,
-       branch_protection_rules: [
-         orgs.newBranchProtectionRule('main') {
-           required_approving_review_count: null,
-           requires_pull_request: false,
-         },
-       ],
-     },
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_alerts_enabled: false,
+      description: "Vert.x Service Resolver",
+      homepage: "",
+      topics+: [
+        "java",
+        "vertx",
+        "jvm",
+        "microservices",
+        "kubernetes",
+        "loadbalancing",
+        "servicediscovery"
+      ],
+      web_commit_signoff_required: false,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          required_approving_review_count: null,
+          requires_pull_request: false,
+        },
+      ],
+    },
   ],
 }


### PR DESCRIPTION
The new vertx-service-resolve repo is missing a couple of configuration items, like the ability to use merge commits which are useful to keep track of long contributions for which we prefer to keep the history.

The indentation has been also corrected.
