### PR TITLE
Add the vertx5 parent pom repo

### DIFF
--- a/otterdog/eclipse-vertx.jsonnet
+++ b/otterdog/eclipse-vertx.jsonnet
@@ -382,5 +382,17 @@ orgs.newOrg('eclipse-vertx') {
         vertxBranchProtectionRule('4.*'),
       ],
     },
+    newVertxRepo('vertx5-parent', 'main') {
+      description: "Vert.x 5 Parent pom",
+      homepage: "",
+      topics+: [
+        "java",
+        "vertx",
+        "maven"
+      ],
+      workflows+: {
+        default_workflow_permissions: "write",
+      },
+    },
   ],
 }


### PR DESCRIPTION
Motivation:

Vert.x 5 requires a different parent pom than Vert.x 4 and Vert.x 3, this repo will host the history of the vertx5 parent pom.