### PR TITLE
Improve the branch protection patterns.

### DIFF
--- a/otterdog/eclipse-vertx.jsonnet
+++ b/otterdog/eclipse-vertx.jsonnet
@@ -100,9 +100,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [
         vertxBranchProtectionRule('master'),
-        vertxBranchProtectionRule('3.*'),
-        vertxBranchProtectionRule('4.*'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
       environments: [
         orgs.newEnvironment('github-pages'),
@@ -130,9 +128,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [
         vertxBranchProtectionRule('master'),
-        vertxBranchProtectionRule('3.*'),
-        vertxBranchProtectionRule('4.*'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
     },
     orgs.newRepo('vertx-codegen') {
@@ -155,9 +151,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [
         vertxBranchProtectionRule('master'),
-        vertxBranchProtectionRule('3.*'),
-        vertxBranchProtectionRule('4.*'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
     },
     orgs.newRepo('vertx-grpc') {
@@ -171,8 +165,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [
         vertxBranchProtectionRule('main'),
-        vertxBranchProtectionRule('4.*'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
     },
     orgs.newRepo('vertx-http-proxy') {
@@ -186,8 +179,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [
         vertxBranchProtectionRule('main'),
-        vertxBranchProtectionRule('4.*'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
     },
     orgs.newRepo('vertx-json-schema') {
@@ -209,8 +201,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [
         vertxBranchProtectionRule('master'),
-        vertxBranchProtectionRule('4.*'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
     },
     orgs.newRepo('vertx-junit5') {
@@ -227,8 +218,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [
         vertxBranchProtectionRule('master'),
-        vertxBranchProtectionRule('4.*'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
     },
     orgs.newRepo('vertx-launcher') {
@@ -246,7 +236,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [
         vertxBranchProtectionRule('main'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
     },
     orgs.newRepo('vertx-openapi') {
@@ -259,8 +249,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [
         vertxBranchProtectionRule('main'),
-        vertxBranchProtectionRule('4.*'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
     },
     orgs.newRepo('vertx-rabbitmq-client') {
@@ -273,7 +262,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [
         vertxBranchProtectionRule('main'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
     },
     orgs.newRepo('vertx-sql-client') {
@@ -304,9 +293,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [
         vertxBranchProtectionRule('master'),
-        vertxBranchProtectionRule('3.*'),
-        vertxBranchProtectionRule('4.*'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
         vertxBranchProtectionRule('_old/*'),
       ],
       environments: [
@@ -334,8 +321,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [
         vertxBranchProtectionRule('master'),
-        vertxBranchProtectionRule('4.*'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
     },
     orgs.newRepo('vertx-uri-template') {
@@ -354,8 +340,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
       },
       branch_protection_rules: [        
         vertxBranchProtectionRule('main'),
-        vertxBranchProtectionRule('4.*'),
-        vertxBranchProtectionRule('5.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
     },
     newVertxRepo('vertx-service-resolver', 'main') {
@@ -392,7 +377,7 @@ orgs.newOrg('rt.vertx', 'eclipse-vertx') {
         default_workflow_permissions: "write",
       },
       branch_protection_rules+: [
-        vertxBranchProtectionRule('4.*'),
+        vertxBranchProtectionRule('[345].[x0123456789]'),
       ],
     },
     newVertxRepo('vertx5-parent', 'main') {


### PR DESCRIPTION
Motivation:

Current branch protection pattern are too conservative: they protect more than they should, e.g. 4.foo is protected and it should not be.

Changes:

Update the branch protection to protect what we need, 3.0 ... 3.9 3.x / 4.0 ... 4.9 4.x / 5.0 ... 5.9 5.x

Result:

More accurate branch protection, more concise rules
